### PR TITLE
pass post metadata to pandoc

### DIFF
--- a/lib/jekyll-pandoc-multiple-formats.rb
+++ b/lib/jekyll-pandoc-multiple-formats.rb
@@ -47,10 +47,12 @@ class PandocGenerator < Generator
 
         # Inform what's being done
         puts pandoc
+        puts "XXX #{post.data.to_yaml}"
 
         # Make the markdown header so pandoc receives metadata
-        content  = "% #{post.data['title']}\n"
-        content << "% #{post.data['author']}\n"
+        content  = "#{post.data.to_yaml}\n---\n"
+        # content  = "% #{post.data['title']}\n"
+        # content << "% #{post.data['author']}\n"
         content << post.content
 
         # Do the stuff

--- a/lib/jekyll-pandoc-multiple-formats.rb
+++ b/lib/jekyll-pandoc-multiple-formats.rb
@@ -47,12 +47,9 @@ class PandocGenerator < Generator
 
         # Inform what's being done
         puts pandoc
-        puts "XXX #{post.data.to_yaml}"
 
         # Make the markdown header so pandoc receives metadata
         content  = "#{post.data.to_yaml}\n---\n"
-        # content  = "% #{post.data['title']}\n"
-        # content << "% #{post.data['author']}\n"
         content << post.content
 
         # Do the stuff


### PR DESCRIPTION
If someone is using a sophisticated template, this would allow an author to eg mark an article as a draft, allowing the template to take advantage of the metadata from the post.


This passes the metadata in the post to pandoc.  In my use case, I wanted to mark articles/technical reports as drafts, and my template will take advantage of this only if the metadata is passed in.
