### PR TITLE
updated the liquid snippet to be more robust

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ other available formats from the post itself:
         {% for format in site.pandoc.outputs %}
         {% capture extension %}{{ format | first }}{% endcapture %}
         <li>
-          <a href="{{ extension }}{{ page.url | remove:'.html' }}.{{ extension }}">
+          <a href="{{ site.baseurl }}/{{ extension }}{{ page.url | remove:'.html' }}.{{ extension }}">
             {{ extension }}
           </a>
         </li>


### PR DESCRIPTION
site.baseurl is used, such that it works no matter how the site is set
up (e.g. when categories structure is included in the permalink