### PR TITLE
Support permalinks with no extension or slash

### DIFF
--- a/lib/jekyll-pandoc-multiple-formats/pandoc_file.rb
+++ b/lib/jekyll-pandoc-multiple-formats/pandoc_file.rb
@@ -43,7 +43,7 @@ module Jekyll
         @title = title
       else
         @posts = [posts]
-        @title = posts.data['title'] unless title
+        @title = title or posts.data['title']
       end
 
       @slug  = Utils.slugify(title)

--- a/lib/jekyll-pandoc-multiple-formats/pandoc_file.rb
+++ b/lib/jekyll-pandoc-multiple-formats/pandoc_file.rb
@@ -46,7 +46,7 @@ module Jekyll
         @title = title or posts.data['title']
       end
 
-      @slug  = Utils.slugify(title)
+      @slug = Utils.slugify(@title)
     end
 
     def path

--- a/lib/jekyll-pandoc-multiple-formats/pandoc_file.rb
+++ b/lib/jekyll-pandoc-multiple-formats/pandoc_file.rb
@@ -26,7 +26,7 @@ module Jekyll
     include Convertible
 
 
-    attr_reader :format, :site, :config, :flags, :posts, :slug, :title, :url
+    attr_reader :format, :site, :config, :flags, :posts, :slug, :title, :url, :is_single_post
     attr_reader :papersize, :sheetsize, :signature
 
     def initialize(site, format, posts, title = nil)
@@ -34,16 +34,17 @@ module Jekyll
       @config = JekyllPandocMultipleFormats::Config.new(@site.config['pandoc']).config
       @format = format
       @flags  = []
+      @is_single_post = not(posts.is_a? Array)
 
-      if posts.is_a? Array
+      if single_post?
+        @posts = [posts]
+        @title = title or posts.data['title']
+      else
         @posts = posts
 
         raise ArgumentError.new "'title' argument is required for multipost file" unless title
 
         @title = title
-      else
-        @posts = [posts]
-        @title = title or posts.data['title']
       end
 
       @slug = Utils.slugify(@title)
@@ -236,7 +237,7 @@ module Jekyll
     end
 
     def single_post?
-      @posts.count == 1
+      @is_single_post
     end
 
     def has_cover?

--- a/lib/jekyll-pandoc-multiple-formats/pandoc_file.rb
+++ b/lib/jekyll-pandoc-multiple-formats/pandoc_file.rb
@@ -67,6 +67,14 @@ module Jekyll
         path << @format
       end
 
+      # if permalink ends with trailing .html or trailing slash, path now ends with proper suffix
+      # for other cases (permalink with no trailing extension or slash), append format
+      # (ie /year/month/slug permalink --> /year/month/slug.pdf)
+      if not path.end_with? ".#{@format}"
+        path << '.'
+        path << @format
+      end
+
       path
     end
 


### PR DESCRIPTION
This pull request adds support for extensionless permalinks with no trailing slash as well as fixes three small bugs in `PandocFile`.  For details, see commit messages.

I've tested this on my own site with permalinks of the forms
  - `/category/title.html`
  - `/category/title/`
  - `/category/title` (new form supported in this PR)

but if you could test it as well, that would be great.